### PR TITLE
Fix: Add reboot-fix.patch for PMIC power register read error during reboot

### DIFF
--- a/recipes-bsp/opensbi/files/reboot-fix.patch
+++ b/recipes-bsp/opensbi/files/reboot-fix.patch
@@ -1,0 +1,143 @@
+diff --git a/platform/generic/starfive/jh7110.c b/platform/generic/starfive/jh7110.c
+index dcd6306..5f5e969 100644
+--- a/platform/generic/starfive/jh7110.c
++++ b/platform/generic/starfive/jh7110.c
+@@ -29,7 +29,7 @@ struct pmic {
+ struct jh7110 {
+ 	u64 pmu_reg_base;
+ 	u64 clk_reg_base;
+-	u32 i2c_index;
++	u32 i2c_clk_offset;
+ };
+ 
+ static struct pmic pmic_inst;
+@@ -67,7 +67,6 @@ static u32 selected_hartid = -1;
+ #define AXP15060_POWER_OFF_BIT		BIT(7)
+ #define AXP15060_RESET_BIT		BIT(6)
+ 
+-#define I2C_APB_CLK_OFFSET		0x228
+ #define I2C_APB_CLK_ENABLE_BIT		BIT(31)
+ 
+ static int pm_system_reset_check(u32 type, u32 reason)
+@@ -130,20 +129,18 @@ static void pmic_ops(struct pmic *pmic, int type)
+ 	u8 val;
+ 
+ 	ret = shutdown_device_power_domain();
+-
+ 	if (ret)
+ 		return;
+ 
+-	if (!sbi_strcmp("stf,axp15060-regulator", pmic->compatible)) {
+-		ret = i2c_adapter_reg_read(pmic->adapter, pmic->dev_addr,
+-					   AXP15060_POWER_REG, &val);
++	ret = i2c_adapter_reg_read(pmic->adapter, pmic->dev_addr,
++					AXP15060_POWER_REG, &val);
+ 
+ 		if (ret) {
+-			sbi_printf("%s: cannot read pmic power register\n",
+-				   __func__);
+-			return;
++		sbi_printf("%s: cannot read pmic power register\n",
++				__func__);
++		return;
+ 		}
+-
++		
+ 		val |= AXP15060_POWER_OFF_BIT;
+ 		if (type == SBI_SRST_RESET_TYPE_SHUTDOWN)
+ 			val |= AXP15060_POWER_OFF_BIT;
+@@ -155,7 +152,6 @@ static void pmic_ops(struct pmic *pmic, int type)
+ 		if (ret)
+ 			sbi_printf("%s: cannot write pmic power register\n",
+ 				   __func__);
+-	}
+ }
+ 
+ static void pmic_i2c_clk_enable(void)
+@@ -163,9 +159,7 @@ static void pmic_i2c_clk_enable(void)
+ 	unsigned long clock_base;
+ 	unsigned int val;
+ 
+-	clock_base = jh7110_inst.clk_reg_base +
+-		I2C_APB_CLK_OFFSET +
+-		(jh7110_inst.i2c_index << 2);
++	clock_base = jh7110_inst.clk_reg_base + jh7110_inst.i2c_clk_offset;
+ 
+ 	val = readl((void *)clock_base);
+ 
+@@ -197,6 +191,8 @@ static struct sbi_system_reset_device pm_reset = {
+ 	.system_reset = pm_system_reset
+ };
+ 
++static int starfive_jh7110_inst_init(void *fdt); 
++
+ static int pm_reset_init(void *fdt, int nodeoff,
+ 			 const struct fdt_match *match)
+ {
+@@ -223,13 +219,17 @@ static int pm_reset_init(void *fdt, int nodeoff,
+ 
+ 	pmic_inst.adapter = adapter;
+ 
++	rc = starfive_jh7110_inst_init(fdt);
++	if (rc)
++		return rc;
++	
+ 	sbi_system_reset_add_device(&pm_reset);
+ 
+ 	return 0;
+ }
+ 
+ static const struct fdt_match pm_reset_match[] = {
+-	{ .compatible = "stf,axp15060-regulator", .data = (void *)true },
++	{ .compatible = "x-powers,axp15060", .data = (void *)true },
+ 	{ },
+ };
+ 
+@@ -241,7 +241,8 @@ static struct fdt_reset fdt_reset_pmic = {
+ static int starfive_jh7110_inst_init(void *fdt)
+ {
+ 	int noff, rc = 0;
+-	const char *name;
++	const fdt32_t *val;
++	int len;
+ 	u64 addr;
+ 
+ 	noff = fdt_node_offset_by_compatible(fdt, -1, "starfive,jh7110-pmu");
+@@ -251,19 +252,25 @@ static int starfive_jh7110_inst_init(void *fdt)
+ 			goto err;
+ 		jh7110_inst.pmu_reg_base = addr;
+ 	}
++	 else {
++		return -SBI_ENODEV; 
++	}
++	noff = fdt_node_offset_by_compatible(fdt, -1, "starfive,jh7110-syscrg");
+ 
+-	noff = fdt_node_offset_by_compatible(fdt, -1, "starfive,jh7110-clkgen");
+ 	if (-1 < noff) {
+ 		rc = fdt_get_node_addr_size(fdt, noff, 0, &addr, NULL);
+ 		if (rc)
+ 			goto err;
+ 		jh7110_inst.clk_reg_base = addr;
++	} else { 			 
++		return -SBI_ENODEV;
+ 	}
+ 
++
+ 	if (pmic_inst.adapter) {
+-		name = fdt_get_name(fdt, pmic_inst.adapter->id, NULL);
+-		if (!sbi_strncmp(name, "i2c", 3))
+-			jh7110_inst.i2c_index = name[3] - '0';
++		val = fdt_getprop(fdt, pmic_inst.adapter->id, "clocks", &len);
++		if (val && len == 8)
++			jh7110_inst.i2c_clk_offset = fdt32_to_cpu(val[1]) << 2;
+ 		else
+ 			rc = SBI_EINVAL;
+ 	}
+@@ -278,7 +285,6 @@ static int starfive_jh7110_final_init(bool cold_boot,
+ 
+ 	if (cold_boot) {
+ 		fdt_reset_driver_init(fdt, &fdt_reset_pmic);
+-		return starfive_jh7110_inst_init(fdt);
+ 	}
+ 
+ 	return 0;

--- a/recipes-bsp/opensbi/opensbi_%.bbappend
+++ b/recipes-bsp/opensbi/opensbi_%.bbappend
@@ -17,6 +17,7 @@ SRC_URI:starfive-dubhe = "\
 SRC_URI:starfive-visionfive2 = "\
 	git://github.com/${FORK}/opensbi.git;protocol=https;branch=${BRANCH} \
 	file://visionfive2-uboot-fit-image.its \
+	file://reboot-fix.patch \
 	"
 
 SRC_URI:starfive-jh8100 = "\


### PR DESCRIPTION
Observed Issue:
- Error encountered while rebooting the device.
- Error Log: [ 1013.263822] reboot: Restarting system pmic_ops: cannot read pmic power register

Debug Steps:
- Added trace log in the related functions to diagnose the issue.

Source: https://patchwork.ozlabs.org/series/396082/mbox/